### PR TITLE
Add hyperlink to similarly named Sherpa package

### DIFF
--- a/docs/welcome.rst
+++ b/docs/welcome.rst
@@ -21,3 +21,9 @@ It provides:
 
 Its goal is to provide a platform in which recent hyperparameter optimization
 algorithms can be used interchangeably while running on a laptop or a cluster.
+
+.. seealso::
+
+   If you are looking for the similarly named package
+   "Sherpa" for modelling and fitting data go here:
+   https://sherpa.readthedocs.io


### PR DESCRIPTION
This other package has a different purpose, but it's close
enough that users could (and have in the past) confused
the two.

xref https://github.com/sherpa/sherpa/pull/821