### PR TITLE
Added extra link when starting dashboard.

### DIFF
--- a/sherpa/core.py
+++ b/sherpa/core.py
@@ -286,8 +286,12 @@ class Study(object):
                                                'host': '',
                                                'threaded': True})
         msg = "\n" + "-"*55 + "\n"
-        msg += "SHERPA Dashboard running. Access via\nhttp://{}:{} if on a cluster or\nhttp://{}:{} if running locally.".format(
-            socket.gethostbyname(socket.gethostname()), port, "localhost", port)
+        msg += "SHERPA Dashboard running. Access via\nhttp://{}:{} or " \
+               "\nhttp://{}:{} if on a cluster, or " \
+               "\nhttp://{}:{} if running locally.".format(
+               socket.gethostbyname(socket.gethostname()), port,
+               socket.gethostname(), port,
+               "localhost", port)
         msg += "\n" + "-"*55
         logger.info(msg)
         


### PR DESCRIPTION
This minor change adds an extra link to the dashboard address when starting the dashboard.  It's redundant, but I found it super convenient to have the hostname rather than the ip address because I am using a proxy switch in my browser to tunnel trafffic to the cluster. 