### PR TITLE
Return GridSearch suggestions in random order.

### DIFF
--- a/sherpa/algorithms/core.py
+++ b/sherpa/algorithms/core.py
@@ -332,19 +332,23 @@ class GridSearch(Algorithm):
 
     Args:
         num_grid_points (int): number of grid points for continuous / discrete.
+        random_order (bool): If true, return suggestions in random order.
 
     """
     allows_repetition = True
 
-    def __init__(self, num_grid_points=2):
+    def __init__(self, num_grid_points=2, random_order=True):
         self.grid = None
         self.num_grid_points = num_grid_points
         self.count = 0  # number of sampled configs
+        self.random_order = random_order
 
     def get_suggestion(self, parameters, results=None, lower_is_better=True):
         if self.count == 0:
             param_dict = self._get_param_dict(parameters)
             self.grid = list(sklearn.model_selection.ParameterGrid(param_dict))
+            if self.random_order:
+                random.shuffle(self.grid)
 
         if self.count >= len(self.grid):
             return AlgorithmState.DONE


### PR DESCRIPTION
This simple update provides an option to randomize the order of the suggestions from GridSearch, and makes this the default behavior. That is, the same finite set of suggestions are returned, just in a randomized order. This is usually preferable to a simple iteration over the parameter space because the intermediate results will have more variety.