### PR TITLE
Require enum34 backport for python less than 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ REQUIRED = [
     'matplotlib'
 ]
 
-if sys.version_info > (3, 4):
+if sys.version_info < (3, 4):
     REQUIRED += ['enum34']
 
 # if args.parallel:


### PR DESCRIPTION
`enum34` is "The enum module from Python3.4 backported from 3.3 - 2.4", from its [description](https://bitbucket.org/stoneleaf/enum34/src/default/). The setup.py currently adds this as a requirement for *greater* versions, instead of lesser versions. This caused an issue with my environment where, on python 3.6+, I need to use a package which cannot install if `enum34` is installed.

This PR changes the requirement to occur only on python versions below 3.4, instead of python versions above 3.4.