### PR TITLE
Prevent int parameters from being cast to float in Bayesian optimization

### DIFF
--- a/sherpa/algorithms/bayesian_optimization.py
+++ b/sherpa/algorithms/bayesian_optimization.py
@@ -261,7 +261,7 @@ class GPyOpt(Algorithm):
             transform = ParameterTransform.from_parameter(p)
             col_dict[p.name] = transform.gpyopt_design_format_to_list_in_sherpa_format(X_next[:, i])
 
-        return list(pandas.DataFrame(col_dict).T.to_dict().values())
+        return list(pandas.DataFrame(col_dict).astype(numpy.object).T.to_dict().values())
 
 
 class ParameterTransform(object):

--- a/tests/test_gpyopt.py
+++ b/tests/test_gpyopt.py
@@ -404,3 +404,22 @@ def test_noisy_parabola():
     # print(rval)
     print(study.results.query("Status=='COMPLETED'"))
     # assert numpy.sqrt((rval['Objective'] - 3.)**2) < 0.2
+
+
+def test_mixed_dtype():
+    algorithm = GPyOpt(max_num_trials=4)
+    parameters = [
+        sherpa.Choice('param_int', [0, 1]),
+        sherpa.Choice('param_float', [0.1, 1.1]),
+    ]
+    study = sherpa.Study(
+        parameters=parameters,
+        algorithm=algorithm,
+        lower_is_better=True,
+        disable_dashboard=True,
+    )
+    for trial in study:
+        study.add_observation(trial, iteration=0, objective=0)
+        study.finalize(trial)
+    assert type(trial.parameters['param_int']) == int
+    assert type(trial.parameters['param_float']) == float


### PR DESCRIPTION
When we request both float and int parameters in Bayesian optimization, right now sherpa returns all parameters as float. This is due to some `pandas` behavior which casts int values to float when taking the transpose of the data frame. This PR fixes this and adds a test to ensure the proper behavior.

The steps to reproduce this issue are as follows:
```
import sherpa

algorithm = sherpa.algorithms.GPyOpt(max_num_trials=4)
parameters = [
    sherpa.Choice('param_int', [0, 1]),
    sherpa.Choice('param_float', [0.1, 1.1]),
]
study = sherpa.Study(
    parameters=parameters,
    algorithm=algorithm,
    lower_is_better=True,
    disable_dashboard=True,
)

for trial in study:
    study.add_observation(trial, iteration=0, objective=0)
    study.finalize(trial)
    assert type(trial.parameters['param_int']) == int
    assert type(trial.parameters['param_float']) == float
```