### PR TITLE
Fixed inconsistency for Discrete parameter in Bayesian optimization

### DIFF
--- a/sherpa/algorithms/bayesian_optimization.py
+++ b/sherpa/algorithms/bayesian_optimization.py
@@ -354,7 +354,7 @@ class DiscreteTransform(ParameterTransform):
         return {'name': self.parameter.name,
                 'type': 'discrete',
                 'domain': tuple(range(self.parameter.range[0],
-                                      self.parameter.range[1]+1))}
+                                      self.parameter.range[1]))}
 
     def gpyopt_design_format_to_list_in_sherpa_format(self, x):
         return list(x.astype('int'))

--- a/tests/test_gpyopt.py
+++ b/tests/test_gpyopt.py
@@ -110,7 +110,7 @@ def test_transformation_to_gpyopt_domain_discrete(parameters):
     for p, d in zip(parameters, domain):
         assert d['name'] == p.name
         assert d['type'] == 'discrete'
-        assert d['domain'] == tuple(range(p.range[0], p.range[1]+1))
+        assert d['domain'] == tuple(range(p.range[0], p.range[1]))
 
 
 def test_transformation_to_gpyopt_domain_log_discrete():
@@ -130,7 +130,7 @@ def test_transformation_to_gpyopt_domain_with_multiple_parameters(parameters):
     assert domain[2]['type'] == 'categorical'
     assert numpy.array_equal(domain[2]['domain'], numpy.array([0, 1, 2]))
     assert {'name': 'num_hidden', 'type': 'discrete',
-            'domain': tuple(range(100,301))} == domain[3]
+            'domain': tuple(range(100,300))} == domain[3]
 
 
 def test_prepare_data_for_bayes_opt(parameters, results):
@@ -404,3 +404,23 @@ def test_noisy_parabola():
     # print(rval)
     print(study.results.query("Status=='COMPLETED'"))
     # assert numpy.sqrt((rval['Objective'] - 3.)**2) < 0.2
+
+
+def test_discrete_range():
+    algorithm = sherpa.algorithms.GPyOpt(max_num_trials=10, verbosity=True)
+    parameters = [
+        sherpa.Discrete('param', [0, 1]),
+    ]
+    study = sherpa.Study(
+        parameters=parameters,
+        algorithm=algorithm,
+        lower_is_better=True,
+        disable_dashboard=True,
+    )
+
+    values = set()
+    for trial in study:
+        study.add_observation(trial, iteration=0, objective=0)
+        study.finalize(trial)
+        values.add(trial.parameters['param'])
+    assert values == set([0])


### PR DESCRIPTION
When using a `Discrete` parameter with the range [a, b] in `RandomSearch`, the values are from a (included) to b (excluded). However the same parameter used in `GpyOpt` will result in values from a (included) to b (included). This PR fixed this inconsistency by modifying the behavior in `GpyOpt`. It also adds a test that ensures that the produced values in a toy example are in the correct range.

The steps to reproduce this issue are as follows (we also look at the values obtained with `RandomSearch` for reference):
```
import sherpa

def create_study(algorithm):
    parameters = [
        sherpa.Discrete('param', [0, 1]),
    ]
    return sherpa.Study(
        parameters=parameters,
        algorithm=algorithm,
        lower_is_better=True,
        disable_dashboard=True,
    )

print('Random Search')
values = set()
algorithm = sherpa.algorithms.RandomSearch(max_num_trials=10)
study = create_study(algorithm)
for trial in study:
    study.add_observation(trial, iteration=0, objective=0)
    study.finalize(trial)
    values.add(trial.parameters['param'])
assert values == set([0]), f'Values found: {values}. Expected: {set([0])}'

print('Bayesian Optimization')
values = set()
algorithm = sherpa.algorithms.GPyOpt(max_num_trials=10, verbosity=True)
study = create_study(algorithm)
for trial in study:
    study.add_observation(trial, iteration=0, objective=0)
    study.finalize(trial)
    values.add(trial.parameters['param'])
assert values == set([0]), f'Values found: {values}. Expected: {set([0])}'
```

